### PR TITLE
Favicon Implementation Update

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -362,7 +362,6 @@ function legendary_toolkit_theme_options_css() {
             --blog_header_background : $blog_header_background;
             --blog_header_content_color: $blog_header_content_color;
             --maintenance_mode_background : $maintenance_mode_background_url;
-            --favicon_url : $favicon_url;
             --btn_border_width: $btn_border_width;
             --btn_border_radius: $btn_border_radius;
             --page_container_width : $page_container_width"."px;
@@ -426,6 +425,20 @@ function my_login_logo() {
     <?php 
 }
 add_action( 'login_enqueue_scripts', 'my_login_logo' );
+
+//Favicon implementation
+function legendary_toolkit_favicon_tag() {
+    $theme_options = legendary_toolkit_get_theme_options();
+    $favicon_id = isset($theme_options['favicon']) ? $theme_options['favicon'] : '';
+    $favicon_url = $favicon_id ? esc_url(wp_get_attachment_url($favicon_id)) : '';
+
+    if ($favicon_url) {
+        ?>
+        <link rel="icon" href="<?php echo $favicon_url; ?>" type="image/png" sizes="512x512">
+        <?php
+    }
+}
+add_action('wp_head', 'legendary_toolkit_favicon_tag');
 
 /**
  * Add Preload for CDN scripts and stylesheet

--- a/inc/options.php
+++ b/inc/options.php
@@ -364,6 +364,7 @@ if ( ! class_exists( 'Legendary_Toolkit_Theme_Options' ) ) {
                             <tr valign="top">
                                 <th scope="row"><?php esc_html_e( 'Favicon', 'legendary-toolkit' );?></th>
                                 <td>
+                                    <p>Please ensure the favicon logo is a 512px x 512px image in PNG format</p>
                                     <?php $value = self::get_theme_option( 'favicon' ); ?>
                                     <input type="hidden" name="theme_options[favicon]" id="favicon" value="<?php echo $value; ?>" />
                                     <div id="favicon_preview" class="favicon btn_favicon toolkit-media-upload" style="background-image:url(<?php echo wp_get_attachment_image_url($value, 'medium'); ?>)" ></div>


### PR DESCRIPTION
Here are my updates to the favicon implementation. Created a new functions in functions.php that injects the favicon into the header. I removed the CSS variable that was previously used in :root and then added new help text in the theme options that asks the user to use a 512x512 PNG. 

Spun up the changes in a local WP installation and it looks like it is working.